### PR TITLE
Add link to DevPack blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Eclipse / Wildfly based Java Enterprise Dev Pack for Windows
 ============================================================
 
-This is a Java / Eclipse / Wildfly dev pack for windows.
+This is a Java / Eclipse / Wildfly [DevPack](http://blog.tknerr.de/blog/2014/10/09/devpack-philosophy-aka-works-on-your-machine/) for windows.
 It includes standard packages needed to develop in such an environment.
 
 General Idea


### PR DESCRIPTION
(shameless plug ;-))

I'm using the same link as the standard explanation for [some](https://github.com/tknerr/ruby-devpack) [other](https://github.com/tknerr/bills-kitchen) devpacks too.
